### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/phkj1/db93599c-3cd8-4fe1-901a-8d3705195de2/cee04757-73f6-4ad2-bd10-3cb42efa8067/_apis/work/boardbadge/eb856fcc-4a97-4adb-9323-f967eba273da)](https://dev.azure.com/phkj1/db93599c-3cd8-4fe1-901a-8d3705195de2/_boards/board/t/cee04757-73f6-4ad2-bd10-3cb42efa8067/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/phkj1/db93599c-3cd8-4fe1-901a-8d3705195de2/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.